### PR TITLE
Implement Android 13 inverted FlatList workaround (HOT-391)

### DIFF
--- a/src/components/BubbleWrapper.tsx
+++ b/src/components/BubbleWrapper.tsx
@@ -179,6 +179,7 @@ const BubbleWrapper = (props: PropsWithChildren<ChatbotBubbleWrapperPropsType> &
   if (!isLatestSetEntry) {
     return (
       <>
+        <Animated.View style={animatedSpacerStyles} />
         <Animated.View style={[styles.row, animatedContainerStyles]}>
           {alignment === 'left' && (
             <Animated.View style={[avatarAnimatedStyles, styles.avatar, { opacity: isLastInGroup ? 1 : 0 }]} />
@@ -191,7 +192,6 @@ const BubbleWrapper = (props: PropsWithChildren<ChatbotBubbleWrapperPropsType> &
             </Animated.View>
           </Animated.View>
         </Animated.View>
-        <Animated.View style={[animatedSpacerStyles]} />
       </>
     )
   }
@@ -200,6 +200,7 @@ const BubbleWrapper = (props: PropsWithChildren<ChatbotBubbleWrapperPropsType> &
 
   return (
     <>
+      <Animated.View style={animatedSpacerStyles} />
       <Animated.View style={[styles.row, animatedContainerStyles]}>
         {alignment === 'left' && (
           <Animated.View style={[avatarAnimatedStyles, styles.avatar, { opacity: isLastInGroup ? 1 : 0 }]}>
@@ -230,7 +231,6 @@ const BubbleWrapper = (props: PropsWithChildren<ChatbotBubbleWrapperPropsType> &
           </Animated.View>
         </Animated.View>
       </Animated.View>
-      <Animated.View style={[animatedSpacerStyles]} />
     </>
   )
 }

--- a/src/components/EntryWrapper.tsx
+++ b/src/components/EntryWrapper.tsx
@@ -3,6 +3,8 @@ import React, { memo, ReactElement, Component, useEffect } from 'react'
 
 import type { DefaultEntryMethodsTypeInternal } from '../types'
 
+import { USE_INVERTED_FLATLIST } from '../index'
+
 interface EntryWrapperType<T> {
   entry: T
   onRender?: DefaultEntryMethodsTypeInternal['onRender']
@@ -78,7 +80,11 @@ const EntryWrapper = <T extends Record<string, unknown>>(props: EntryWrapperType
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return <Comp />
+  return (
+    <View style={[!USE_INVERTED_FLATLIST && { transform: [{ rotate: '180deg' }] }]}>
+      <Comp />
+    </View>
+  )
 }
 
 export default memo(EntryWrapper, (prevProps, nextProps) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { FlatList } from 'react-native-gesture-handler'
-import { View, StyleProp, ViewStyle } from 'react-native'
+import { View, StyleProp, ViewStyle, Platform } from 'react-native'
 import React, { memo, useCallback, useEffect, useState } from 'react'
 import Animated, { useAnimatedStyle, withSpring } from 'react-native-reanimated'
 
@@ -24,6 +24,15 @@ interface ChatbotPropsType<K, T> {
   setChatbotHistory: (newHistoryKey: keyof K | Record<string, unknown>) => void
   onEntryWillUpdate?: ((nextEntryKey: keyof K | Record<string, unknown>) => void | Promise<void>) | undefined
 }
+
+/**
+ * A boolean indicating, whether chatbot container and the bubbles within it should use inverted FlatList (true)
+ * or be flipped manually using transform instead (false).
+ * This is a "hack" to prevent bad performance, laggy animations and app freezing when using an
+ * inverted FlatList on Android 13.
+ * @see https://github.com/facebook/react-native/issues/34583
+ */
+export const USE_INVERTED_FLATLIST = !(Platform.OS === 'android' && Platform.Version >= 33)
 
 const Chatbot = <
   K extends Record<
@@ -109,12 +118,12 @@ const Chatbot = <
   return (
     <View style={{ flex: 1 }}>
       <AnimatedFlatList
-        inverted
         data={chatbotHistory}
+        inverted={USE_INVERTED_FLATLIST}
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={contentContainerStyle}
         showsVerticalScrollIndicator={false}
-        style={[{ flex: 1 }, animatedPadding]}
+        contentContainerStyle={contentContainerStyle}
+        style={[{ flex: 1 }, animatedPadding, !USE_INVERTED_FLATLIST && { transform: [{ rotate: '180deg' }] }]}
         keyExtractor={(item, index): string => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore


### PR DESCRIPTION
This PR implements:
- Use non-inverted FlatList on Android 13 to improve UI performance and prevent the app from freezing

See the original React Native issue here: https://github.com/facebook/react-native/issues/34583.